### PR TITLE
add arch/manjaro support and remove conflict

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,8 @@ linuxInstall(){
     cmd="dnf install"
   elif command -v zypper &>/dev/null; then
     cmd="zypper install"
+  elif command -v pacman &>/dev/null; then # ldid is on AUR... use yay or git clone + makepkg
+    cmd="pacman -S"
   else
     cmd="true"
   fi
@@ -108,7 +110,7 @@ installDragonBuild() {
 
   echo "Installing DragonBuild..."
 
-# we're root and want to install as the user we where called from
+# we're root and want to install as the user we were called from
   cat << EOF | su ${INSTALL_USER} -c bash
     shopt -s extglob nullglob
     set -e
@@ -135,7 +137,11 @@ EOF
 
   local _HOME="$(su ${INSTALL_USER} -c echo ${HOME})"
 
-  ln -s ${_HOME}/.dragonbuild/dragon /usr/local/bin/dragon || :
+  if [ -f /usr/bin/dragon ]; then # KDE Dragon Player
+    ln -s ${_HOME}/.dragonbuild/dragon /usr/local/bin/dragonbuild || : # does not conflict
+  else
+    ln -s ${_HOME}/.dragonbuild/dragon /usr/local/bin/dragon || :
+  fi
 }
 
 installDragonBuild


### PR DESCRIPTION
Arch and Manjaro use `pacman` as their package manager.
Also, KDE Plasma has a program known as [Dragon Player](https://kde.org/applications/en/dragonplayer) and its executable lives at `/usr/bin/dragon`. By moving the `dragon`  symlink this script creates to `/usr/local/bin/dragonbuild` both programs can be called by just their executable names.

Side note: Why is dpkg needed? `pacman` even gives a warning when installing it.